### PR TITLE
Update android core version to fix some compile issues.

### DIFF
--- a/make_a_map/build.gradle
+++ b/make_a_map/build.gradle
@@ -16,7 +16,7 @@
 
 dependencies {
   compile 'com.github.rosjava.android_remocons:common_tools:[0.2,0.3)'
-  compile 'org.ros.android_core:android_15:[0.2,0.3)'
+  compile 'org.ros.android_core:android_15:[0.3,0.4)'
   compile 'org.ros.rosjava_core:rosjava_geometry:[0.2,0.3)'
   compile 'org.ros.rosjava_messages:map_store:[0.3,0.4)'
   compile 'org.ros.rosjava_messages:world_canvas_msgs:[0.1,0.2)'

--- a/make_a_map/build.gradle
+++ b/make_a_map/build.gradle
@@ -17,9 +17,9 @@
 dependencies {
   compile 'com.github.rosjava.android_remocons:common_tools:[0.2,0.3)'
   compile 'org.ros.android_core:android_15:[0.3,0.4)'
-  compile 'org.ros.rosjava_core:rosjava_geometry:[0.2,0.3)'
+  compile 'org.ros.rosjava_core:rosjava_geometry:[0.3,0.4)'
   compile 'org.ros.rosjava_messages:map_store:[0.3,0.4)'
-  compile 'org.ros.rosjava_messages:world_canvas_msgs:[0.1,0.2)'
+  compile 'org.ros.rosjava_messages:world_canvas_msgs:[0.2,0.3)'
 }
 
 apply plugin: 'com.android.application'

--- a/map_manager/build.gradle
+++ b/map_manager/build.gradle
@@ -16,7 +16,7 @@
 dependencies {
   compile 'com.github.rosjava.android_remocons:common_tools:[0.2,0.3)'
   compile 'org.ros.android_core:android_15:[0.3,0.4)'
-  compile 'org.ros.rosjava_messages:world_canvas_msgs:[0.1,0.2)'
+  compile 'org.ros.rosjava_messages:world_canvas_msgs:[0.2,0.3)'
 }
 
 apply plugin: 'com.android.application'

--- a/map_manager/build.gradle
+++ b/map_manager/build.gradle
@@ -15,7 +15,7 @@
  */
 dependencies {
   compile 'com.github.rosjava.android_remocons:common_tools:[0.2,0.3)'
-  compile 'org.ros.android_core:android_15:[0.2,0.3)'
+  compile 'org.ros.android_core:android_15:[0.3,0.4)'
   compile 'org.ros.rosjava_messages:world_canvas_msgs:[0.1,0.2)'
 }
 

--- a/map_nav/build.gradle
+++ b/map_nav/build.gradle
@@ -16,10 +16,10 @@
 dependencies {
   compile 'com.github.rosjava.android_remocons:common_tools:[0.2,0.3)'
   compile 'org.ros.android_core:android_15:[0.3,0.4)'
-  compile 'org.ros.rosjava_core:rosjava_geometry:[0.2,0.3)'
+  compile 'org.ros.rosjava_core:rosjava_geometry:[0.3,0.4)'
   compile 'org.ros.rosjava_messages:map_store:[0.3,0.4)'
   compile 'org.ros.rosjava_messages:move_base_msgs:[1.12,1.13)'
-  compile 'org.ros.rosjava_messages:world_canvas_msgs:[0.1,0.2)'
+  compile 'org.ros.rosjava_messages:world_canvas_msgs:[0.2,0.3)'
 }
 
 apply plugin: 'com.android.application'

--- a/map_nav/build.gradle
+++ b/map_nav/build.gradle
@@ -15,7 +15,7 @@
  */
 dependencies {
   compile 'com.github.rosjava.android_remocons:common_tools:[0.2,0.3)'
-  compile 'org.ros.android_core:android_15:[0.2,0.3)'
+  compile 'org.ros.android_core:android_15:[0.3,0.4)'
   compile 'org.ros.rosjava_core:rosjava_geometry:[0.2,0.3)'
   compile 'org.ros.rosjava_messages:map_store:[0.3,0.4)'
   compile 'org.ros.rosjava_messages:move_base_msgs:[1.12,1.13)'

--- a/teleop/build.gradle
+++ b/teleop/build.gradle
@@ -16,7 +16,7 @@
 
 dependencies {
   compile 'com.github.rosjava.android_remocons:common_tools:[0.2,0.3)'
-  compile 'org.ros.android_core:android_15:[0.2,0.3)'
+  compile 'org.ros.android_core:android_15:[0.3,0.4)'
 }
 
 apply plugin: 'com.android.application'


### PR DESCRIPTION
This PR updates the `android_15` version to 0.3+ which solves the compile errors reported in #51 and #55.