### PR TITLE
Don't load list by default and other fixes

### DIFF
--- a/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/InitialPoseSubscriberLayer.java
+++ b/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/InitialPoseSubscriberLayer.java
@@ -15,7 +15,7 @@ import javax.microedition.khronos.opengles.GL10;
 
 
 public class InitialPoseSubscriberLayer extends
-		SubscriberLayer<geometry_msgs.PoseStamped> implements TfLayer {
+		SubscriberLayer<geometry_msgs.PoseWithCovarianceStamped> implements TfLayer {
 
 	private final GraphName targetFrame;
 
@@ -26,7 +26,7 @@ public class InitialPoseSubscriberLayer extends
 	}
 
 	public InitialPoseSubscriberLayer(GraphName topic, String robotFrame) {
-		super(topic, "geometry_msgs/PoseStamped");
+		super(topic, "geometry_msgs/PoseWithCovarianceStamped");
 		targetFrame = GraphName.of(robotFrame);
 	}
 
@@ -40,15 +40,15 @@ public class InitialPoseSubscriberLayer extends
         super.onStart(view, connectedNode);
         shape = new GoalShape();
 		getSubscriber().addMessageListener(
-				new MessageListener<geometry_msgs.PoseStamped>() {
+				new MessageListener<geometry_msgs.PoseWithCovarianceStamped>() {
 					@Override
-					public void onNewMessage(geometry_msgs.PoseStamped pose) {
+					public void onNewMessage(geometry_msgs.PoseWithCovarianceStamped pose) {
                         GraphName source = GraphName.of(pose.getHeader()
 								.getFrameId());
 						FrameTransform frameTransform = view.getFrameTransformTree().transform(source, targetFrame);
 						if (frameTransform != null) {
 							Transform poseTransform = Transform
-									.fromPoseMessage(pose.getPose());
+									.fromPoseMessage(pose.getPose().getPose());
 							shape.setTransform(frameTransform.getTransform()
 									.multiply(poseTransform));
 						}

--- a/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/MainActivity.java
+++ b/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/MainActivity.java
@@ -45,10 +45,12 @@ import org.ros.namespace.NameResolver;
 import org.ros.node.NodeConfiguration;
 import org.ros.node.NodeMainExecutor;
 import org.ros.node.service.ServiceResponseListener;
+import org.ros.time.NtpTimeProvider;
 
 import java.sql.Date;
 import java.text.DateFormat;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import world_canvas_msgs.ListMapsResponse;
 import world_canvas_msgs.MapListEntry;
@@ -177,15 +179,12 @@ public class MainActivity extends RosAppActivity {
             public void onRotate(float focusX, float focusY, double deltaAngle) {}
         });
 
-
-//		NtpTimeProvider ntpTimeProvider = new NtpTimeProvider(
-//				InetAddressFactory.newFromHostString("192.168.0.1"),
-//				nodeMainExecutor.getScheduledExecutorService());
-//		ntpTimeProvider.startPeriodicUpdates(1, TimeUnit.MINUTES);
-//		nodeConfiguration.setTimeProvider(ntpTimeProvider);
+		NtpTimeProvider ntpTimeProvider = new NtpTimeProvider(
+				InetAddressFactory.newFromHostString("pool.ntp.org"),
+				nodeMainExecutor.getScheduledExecutorService());
+		ntpTimeProvider.startPeriodicUpdates(1, TimeUnit.MINUTES);
+		nodeConfiguration.setTimeProvider(ntpTimeProvider);
 		nodeMainExecutor.execute(mapView, nodeConfiguration.setNodeName("android/map_view"));
-
-		readAvailableMapList();
 	}
 
 	private void onChooseMapButtonPressed() {


### PR DESCRIPTION
This change allows using map_nav also with empty or pre-loaded maps.
If the map manager needs to be used, there is still the "choose map" button for this purpose.
This also fixes a couple of nits: re-enables NTP and fixes a wrong type in the `/initialpose` publisher.

@jubeira @ernestmc can one of you let me know what you think?

@tulku FYI