### PR TITLE
Display local costmap on top of map

### DIFF
--- a/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/MainActivity.java
+++ b/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/MainActivity.java
@@ -147,13 +147,15 @@ public class MainActivity extends RosAppActivity {
                 		nodeMainExecutor.getScheduledExecutorService(), cameraView,
                 		mapView, mainLayout, sideLayout, params);
 
-        String mapTopic   = remaps.get(getString(R.string.map_topic));
-        String scanTopic  = remaps.get(getString(R.string.scan_topic));
-        String planTopic  = remaps.get(getString(R.string.global_plan_topic));
-        String initTopic  = remaps.get(getString(R.string.initial_pose_topic));
-        String robotFrame = (String) params.get("robot_frame", getString(R.string.robot_frame));
+        String mapTopic      = remaps.get(getString(R.string.map_topic));
+        String costmapTopic  = remaps.get(getString(R.string.costmap_topic));
+        String scanTopic     = remaps.get(getString(R.string.scan_topic));
+        String planTopic     = remaps.get(getString(R.string.global_plan_topic));
+        String initTopic     = remaps.get(getString(R.string.initial_pose_topic));
+        String robotFrame    = (String) params.get("robot_frame", getString(R.string.robot_frame));
 
-        OccupancyGridLayer occupancyGridLayer = new OccupancyGridLayer(appNameSpace.resolve(mapTopic).toString());
+        OccupancyGridLayer mapLayer = new OccupancyGridLayer(appNameSpace.resolve(mapTopic).toString());
+		OccupancyGridLayer costmapLayer = new OccupancyGridLayer(appNameSpace.resolve(costmapTopic).toString());
         LaserScanLayer laserScanLayer = new LaserScanLayer(appNameSpace.resolve(scanTopic).toString());
         PathLayer pathLayer = new PathLayer(appNameSpace.resolve(planTopic).toString());
         mapPosePublisherLayer = new com.github.rosjava.android_apps.map_nav.MapPosePublisherLayer(this, appNameSpace, params, remaps);
@@ -161,7 +163,8 @@ public class MainActivity extends RosAppActivity {
                 new com.github.rosjava.android_apps.map_nav.InitialPoseSubscriberLayer(appNameSpace.resolve(initTopic).toString(), robotFrame);
 
         mapView.addLayer(viewControlLayer);
-        mapView.addLayer(occupancyGridLayer);
+        mapView.addLayer(mapLayer);
+        mapView.addLayer(costmapLayer);
         mapView.addLayer(laserScanLayer);
         mapView.addLayer(pathLayer);
         mapView.addLayer(mapPosePublisherLayer);

--- a/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/MainActivity.java
+++ b/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/MainActivity.java
@@ -155,7 +155,7 @@ public class MainActivity extends RosAppActivity {
         String robotFrame    = (String) params.get("robot_frame", getString(R.string.robot_frame));
 
         OccupancyGridLayer mapLayer = new OccupancyGridLayer(appNameSpace.resolve(mapTopic).toString());
-		OccupancyGridLayer costmapLayer = new OccupancyGridLayer(appNameSpace.resolve(costmapTopic).toString());
+        OccupancyGridLayer costmapLayer = new OccupancyGridLayer(appNameSpace.resolve(costmapTopic).toString());
         LaserScanLayer laserScanLayer = new LaserScanLayer(appNameSpace.resolve(scanTopic).toString());
         PathLayer pathLayer = new PathLayer(appNameSpace.resolve(planTopic).toString());
         mapPosePublisherLayer = new com.github.rosjava.android_apps.map_nav.MapPosePublisherLayer(this, appNameSpace, params, remaps);

--- a/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/MapPosePublisherLayer.java
+++ b/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/MapPosePublisherLayer.java
@@ -168,7 +168,7 @@ public class MapPosePublisherLayer extends DefaultLayer {
 	public void onStart(final VisualizationView view, ConnectedNode connectedNode) {
 		this.connectedNode = connectedNode;
 		shape = new PixelSpacePoseShape();
-		mode = POSE_MODE;
+		mode = GOAL_MODE;
 
 		initialPosePublisher = connectedNode.newPublisher(nameResolver.resolve(initialPoseTopic).toString(),
 				                                          "geometry_msgs/PoseWithCovarianceStamped");

--- a/map_nav/src/main/res/values/strings.xml
+++ b/map_nav/src/main/res/values/strings.xml
@@ -9,8 +9,9 @@
     <string name="camera_topic">compressed_image</string>
     <string name="joystick_topic">cmd_vel</string>
     <string name="map_topic">map</string>
+    <string name="costmap_topic">/move_base/local_costmap/costmap</string>
     <string name="scan_topic">scan</string>
-    <string name="global_plan_topic">move_base/TrajectoryPlannerROS/global_plan</string>
+    <string name="global_plan_topic">move_base/NavfnROS/plan</string>
     <string name="initial_pose_topic">initialpose</string>
     <string name="simple_goal_topic">move_base_simple/goal</string>
     <string name="move_base_goal_topic">move_base/goal</string>


### PR DESCRIPTION
This PR adds a layer in the view that shows the local costmap overlaid on top of the map and the rest of the views.

Two other minor bug fixes are included:
 - Changed subscribed topic name for planned path to match default Tangobot configuration
 - Updated default map selection logic from pose setting to goal setting

@jubeira could you please review?