### PR TITLE
Small fix for race condition at start for map_nav

### DIFF
--- a/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/InitialPoseSubscriberLayer.java
+++ b/map_nav/src/main/java/com.github.rosjava.android_apps.map_nav/InitialPoseSubscriberLayer.java
@@ -23,6 +23,7 @@ public class InitialPoseSubscriberLayer extends
 
 	public InitialPoseSubscriberLayer(String topic, String robotFrame) {
 		this(GraphName.of(topic), robotFrame);
+		shape = new GoalShape();
 	}
 
 	public InitialPoseSubscriberLayer(GraphName topic, String robotFrame) {
@@ -38,7 +39,6 @@ public class InitialPoseSubscriberLayer extends
 	@Override
 	public void onStart(final VisualizationView view, ConnectedNode connectedNode) {
         super.onStart(view, connectedNode);
-        shape = new GoalShape();
 		getSubscriber().addMessageListener(
 				new MessageListener<geometry_msgs.PoseWithCovarianceStamped>() {
 					@Override


### PR DESCRIPTION
That `shape` object is sometimes used by the app before `onStart`, making the app crash.
@adamantivm ptal